### PR TITLE
PIZ8: Fix the selected item view in the header

### DIFF
--- a/app/beverage/add-beverage.html
+++ b/app/beverage/add-beverage.html
@@ -39,7 +39,7 @@
         <ul class="navbar-nav">
           <!-- LINKS -->
 
-          <li class="nav-item active">
+          <li class="nav-item">
             <a class="nav-link" href="/">Build Your Pizza!</a>
           </li>
           <li class="nav-item">
@@ -53,7 +53,7 @@
           <li class="nav-item">
             <a class="nav-link" href="/app/size/sizes.html">Sizes</a>
           </li>
-          <li class="nav-item">
+          <li class="nav-item active">
             <a class="nav-link" href="/app/beverage/beverages.html"
               >Beverages</a
             >

--- a/app/beverage/beverages.html
+++ b/app/beverage/beverages.html
@@ -39,7 +39,7 @@
         <ul class="navbar-nav">
           <!-- LINKS -->
 
-          <li class="nav-item active">
+          <li class="nav-item">
             <a class="nav-link" href="/">Build Your Pizza!</a>
           </li>
           <li class="nav-item">
@@ -53,7 +53,7 @@
           <li class="nav-item">
             <a class="nav-link" href="/app/size/sizes.html">Sizes</a>
           </li>
-          <li class="nav-item">
+          <li class="nav-item active">
             <a class="nav-link" href="/app/beverage/beverages.html"
               >Beverages</a
             >

--- a/app/beverage/update-beverage.html
+++ b/app/beverage/update-beverage.html
@@ -39,7 +39,7 @@
         <ul class="navbar-nav">
           <!-- LINKS -->
 
-          <li class="nav-item active">
+          <li class="nav-item">
             <a class="nav-link" href="/">Build Your Pizza!</a>
           </li>
           <li class="nav-item">
@@ -53,7 +53,7 @@
           <li class="nav-item">
             <a class="nav-link" href="/app/size/sizes.html">Sizes</a>
           </li>
-          <li class="nav-item">
+          <li class="nav-item active">
             <a class="nav-link" href="/app/beverage/beverages.html"
               >Beverages</a
             >

--- a/app/ingredient/add-ingredient.html
+++ b/app/ingredient/add-ingredient.html
@@ -39,13 +39,13 @@
         <ul class="navbar-nav">
           <!-- LINKS -->
 
-          <li class="nav-item active">
+          <li class="nav-item">
             <a class="nav-link" href="/">Build Your Pizza!</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="/app/order/orders.html">Orders</a>
           </li>
-          <li class="nav-item">
+          <li class="nav-item active">
             <a class="nav-link" href="/app/ingredient/ingredients.html"
               >Ingredients</a
             >

--- a/app/ingredient/ingredients.html
+++ b/app/ingredient/ingredients.html
@@ -39,13 +39,13 @@
         <ul class="navbar-nav">
           <!-- LINKS -->
 
-          <li class="nav-item active">
+          <li class="nav-item">
             <a class="nav-link" href="/">Build Your Pizza!</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="/app/order/orders.html">Orders</a>
           </li>
-          <li class="nav-item">
+          <li class="nav-item active">
             <a class="nav-link" href="/app/ingredient/ingredients.html"
               >Ingredients</a
             >

--- a/app/ingredient/update-ingredient.html
+++ b/app/ingredient/update-ingredient.html
@@ -39,13 +39,13 @@
         <ul class="navbar-nav">
           <!-- LINKS -->
 
-          <li class="nav-item active">
+          <li class="nav-item">
             <a class="nav-link" href="/">Build Your Pizza!</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="/app/order/orders.html">Orders</a>
           </li>
-          <li class="nav-item">
+          <li class="nav-item active">
             <a class="nav-link" href="/app/ingredient/ingredients.html"
               >Ingredients</a
             >

--- a/app/order/order-detail.html
+++ b/app/order/order-detail.html
@@ -39,10 +39,10 @@
         <ul class="navbar-nav">
           <!-- LINKS -->
 
-          <li class="nav-item active">
+          <li class="nav-item">
             <a class="nav-link" href="/">Build Your Pizza!</a>
           </li>
-          <li class="nav-item">
+          <li class="nav-item active">
             <a class="nav-link" href="/app/order/orders.html">Orders</a>
           </li>
           <li class="nav-item">

--- a/app/order/orders.html
+++ b/app/order/orders.html
@@ -39,10 +39,10 @@
         <ul class="navbar-nav">
           <!-- LINKS -->
 
-          <li class="nav-item active">
+          <li class="nav-item">
             <a class="nav-link" href="/">Build Your Pizza!</a>
           </li>
-          <li class="nav-item">
+          <li class="nav-item active">
             <a class="nav-link" href="/app/order/orders.html">Orders</a>
           </li>
           <li class="nav-item">

--- a/app/size/add-size.html
+++ b/app/size/add-size.html
@@ -39,7 +39,7 @@
         <ul class="navbar-nav">
           <!-- LINKS -->
 
-          <li class="nav-item active">
+          <li class="nav-item">
             <a class="nav-link" href="/">Build Your Pizza!</a>
           </li>
           <li class="nav-item">
@@ -50,7 +50,7 @@
               >Ingredients</a
             >
           </li>
-          <li class="nav-item">
+          <li class="nav-item active">
             <a class="nav-link" href="/app/size/sizes.html">Sizes</a>
           </li>
           <li class="nav-item">

--- a/app/size/sizes.html
+++ b/app/size/sizes.html
@@ -39,7 +39,7 @@
         <ul class="navbar-nav">
           <!-- LINKS -->
 
-          <li class="nav-item active">
+          <li class="nav-item">
             <a class="nav-link" href="/">Build Your Pizza!</a>
           </li>
           <li class="nav-item">
@@ -50,7 +50,7 @@
               >Ingredients</a
             >
           </li>
-          <li class="nav-item">
+          <li class="nav-item active">
             <a class="nav-link" href="/app/size/sizes.html">Sizes</a>
           </li>
           <li class="nav-item">

--- a/app/size/update-size.html
+++ b/app/size/update-size.html
@@ -39,7 +39,7 @@
         <ul class="navbar-nav">
           <!-- LINKS -->
 
-          <li class="nav-item active">
+          <li class="nav-item">
             <a class="nav-link" href="/">Build Your Pizza!</a>
           </li>
           <li class="nav-item">
@@ -50,7 +50,7 @@
               >Ingredients</a
             >
           </li>
-          <li class="nav-item">
+          <li class="nav-item active">
             <a class="nav-link" href="/app/size/sizes.html">Sizes</a>
           </li>
           <li class="nav-item">


### PR DESCRIPTION
Trello task: [PIZ8 - Fix the selected item view in the header](https://trello.com/c/Ttgbvlmy)

Summary:

- The navigation bar always showed the 'Build Your Pizza!' option selected and when the user navigates in the application this option never change.
- The 'active' attribute in HTML lists can help us to do this task only setting as 'active'
 the item in the list of the header.

Changes:

- app/beverage/add-beverage.html
- app/beverage/add-beverage.html
- app/beverage/update-beverage.html
- app/ingredient/add-ingredient.html
- app/ingredient/ingredients.html
- app/ingredient/update-ingredient.html
- app/order/order-detail.html
- app/order/orders.html
- app/size/add-size.html
- app/size/sizes.html
- app/size/update-size.html

In all of this files, I changed the 'active' option in the correspondent item in the list of the header.

Captures:

![image](https://user-images.githubusercontent.com/44406603/187526732-ef15eea5-464b-4b43-8f17-0f9c69439de1.png)
![image](https://user-images.githubusercontent.com/44406603/187526769-039082e5-b7f6-4a94-85d8-366007b7800c.png)
![image](https://user-images.githubusercontent.com/44406603/187526805-ed4ed4c8-09b1-4afb-83e4-c24e8f48c0f0.png)
![image](https://user-images.githubusercontent.com/44406603/187526836-11b7b83a-e024-47f4-9d2d-fe4681911689.png)
![image](https://user-images.githubusercontent.com/44406603/187526870-ebbb5902-dcc3-4464-af22-127c39b8009a.png)
