### PR TITLE
PIZ12: Fix the reports page when the database is empty

### DIFF
--- a/js/report/report.js
+++ b/js/report/report.js
@@ -1,9 +1,11 @@
 fetch("http://127.0.0.1:5000/report/")
   .then((response) => response.json())
   .then((report_data) => {
-    let row = createReportTemplate(report_data);
-    let table = $("#report tbody");
-    table.append(row);
+    if (!report_data.error) {
+      let row = createReportTemplate(report_data);
+      let table = $("#report tbody");
+      table.append(row);
+    }
   });
 
 function createReportTemplate(report) {


### PR DESCRIPTION
Trello task: [PIZ12 - Fix the reports page when the database is empty (Bug)](https://trello.com/c/Vl0l8BzN)

Summary:

- To fix this bug I only had to do one validation in the orders requesting.

Changes:

- js/report/report.js: to add a validation in the table rendering.

Captures:

![image](https://user-images.githubusercontent.com/44406603/188100920-a29fa85e-9db8-4de3-bd84-0edc1e78ca97.png)